### PR TITLE
Authorise gsutil

### DIFF
--- a/scripts/container_run.sh
+++ b/scripts/container_run.sh
@@ -2,6 +2,8 @@
 
 set -eu
 
+printf '[Credentials]\ngs_service_key_file=%s' "${GOOGLE_APPLICATION_CREDENTIALS}" > ~/.boto
+
 echo "==> Erasing bucket working directory..."
 
 gsutil ls "gs://$SCRATCH_BUCKET_NAME/*" 1> /dev/null  # to check authorisation


### PR DESCRIPTION
I don't know why, but it looks like `gcloud` (and hence `gsutil`)
doesn't pick up the service account credentials added to the container
by Vertex AI. It works for the Python client. This worked on my local
tests where I mounted the service account key in the container and
specified the path to it using `GOOGLE_APPLICATION_CREDENTIALS`.
